### PR TITLE
Adding more logic to the clean-up script

### DIFF
--- a/script/clean-up
+++ b/script/clean-up
@@ -15,7 +15,7 @@ function makebranch () {
 
 function cleanup () {
   mv class-pins.topojson class-pins
-  if [ ! -f "*.topojson" ]; then
+  if [ ! -f *.topojson ]; then
     echo ":frown: there are no new topojson files!"
     mv class-pins class-pins.topojson
     git checkout master

--- a/script/clean-up
+++ b/script/clean-up
@@ -1,11 +1,46 @@
-git pull
-git checkout -b cleanup-and-merge
-mv class-pins.topojson class-pins
-geojson-merge *.topojson class-pins > class-pins.topojson
-rm class-pins
-mv class-pins.topojson class-pins
-rm *.topojson
-mv class-pins class-pins.topojson
-git add -A
-git commit -m "clean up class files"
-git push -u origin cleanup-and-merge
+#!/bin/sh
+
+function makebranch () {
+  git checkout master
+  git pull --prune
+  if git branch | grep cleanup-and-merge ;
+    then
+      git checkout cleanup-and-merge
+      git merge origin/cleanup-and-merge
+    else
+      git checkout -b cleanup-and-merge
+  fi
+  cleanup
+}
+
+function cleanup () {
+  mv class-pins.topojson class-pins
+  if [ ! -f "*.topojson" ]; then
+    echo ":frown: there are no new topojson files!"
+    mv class-pins class-pins.topojson
+    git checkout master
+    git branch -d cleanup-and-merge
+    exit
+  else
+    echo ":tada: I found new files, combining and pushing now!"
+    geojson-merge *.topojson class-pins > class-pins.topojson
+    rm class-pins
+    mv class-pins.topojson class-pins
+    rm *.topojson
+    mv class-pins class-pins.topojson
+    git add -A
+    git commit -m "clean up class files"
+    git push -u origin cleanup-and-merge
+    echo "All done. Please go create the PR and merge if tests are passing!"
+  fi
+}
+
+if npm list -g | grep geojson-merge ;
+then
+  makebranch
+else
+  echo "You must have the npm package geojson-merge installed"
+  echo "at the global scope before running this script."
+  echo "Please do npm install -g geojson-merge and try again."
+  exit
+fi


### PR DESCRIPTION
The clean-up script can currently be run by anyone with push access to this repo. This PR adds some logic to ensure dependencies are installed with the correct scope before running the script.