### PR TITLE
Add Chatsworth, CA to map

### DIFF
--- a/lattegirrl-chatsworth.topojson
+++ b/lattegirrl-chatsworth.topojson
@@ -1,0 +1,1 @@
+{ "type": "Feature", "geometry": {"type": "Point", "coordinates": [-118.6011992, 34.2572252]}, "properties": {"username": "lattegirrl"} } 


### PR DESCRIPTION
@githubteacher - Added map pin for Chatsworth, CA. Closes #235 