### PR TITLE
Add Sioux Falls, SD, to pins

### DIFF
--- a/_pins/awayken.json
+++ b/_pins/awayken.json
@@ -1,0 +1,5 @@
+---
+githubHandle: awayken
+latitude: 43.544596
+longitude: -96.731103
+---


### PR DESCRIPTION
@githubteacher Adding the latitude and longitude for Sioux Falls, SD, to the `_pins` directory.

closes #684 