### PR TITLE
Add lat/lon coordinates for Fontana

### DIFF
--- a/_pins/thumper195.json
+++ b/_pins/thumper195.json
@@ -1,0 +1,5 @@
+---
+githubHandle: Thumper195
+latitude: 34.092232
+longitude:  -117.435051
+---


### PR DESCRIPTION
added coordinates for plotting a pin for the location of the city of Fontana, CA
@githubteacher 
closes #710 