### PR TITLE
Add vestal, NY to map

### DIFF
--- a/_pins/dchannin.json
+++ b/_pins/dchannin.json
@@ -1,0 +1,5 @@
+---
+githubHandle: dchannin
+latitude: 42.085590
+longitude: -76.053575
+---


### PR DESCRIPTION
@githubteacher Closes #791. adding Vestal, NY to map because it's a great place to live.