### PR TITLE
add lat/long for Sachse

### DIFF
--- a/_pins/tomhoover.json
+++ b/_pins/tomhoover.json
@@ -1,0 +1,5 @@
+---
+githubHandle: tomhoover
+latitude: 32.976233
+longitude: -96.595270
+---


### PR DESCRIPTION
This will add a pin for Sachse, TX. @githubteacher, this closes #1016.