### PR TITLE
Add a pin with St.Petersburg (Russia) location

### DIFF
--- a/_pins/iradche.json
+++ b/_pins/iradche.json
@@ -1,0 +1,5 @@
+---
+githubHandle: iradche
+latitude: 59.934280
+longitude: 30.335099
+---


### PR DESCRIPTION
@githubteacher please add St.Petersburg (Russia) location to the map that closes #1119 