### PR TITLE
Adding pins found in stray repos

### DIFF
--- a/_pins/AdryxnLink.json
+++ b/_pins/AdryxnLink.json
@@ -1,0 +1,5 @@
+---
+githubHandle: AdryxnLink
+latitude: 31.723039
+longitude: -106.424013
+---

--- a/_pins/ChadH1971.json
+++ b/_pins/ChadH1971.json
@@ -1,0 +1,5 @@
+---
+githubHandle: ChadH1971
+latitude: 35.410511
+longitude: -118.971559
+---

--- a/_pins/alrightjones.json
+++ b/_pins/alrightjones.json
@@ -1,0 +1,5 @@
+---
+githubHandle: alrightjones
+latitude: 37.775928
+longitude: -122.444024
+---

--- a/_pins/amyrrich.json
+++ b/_pins/amyrrich.json
@@ -1,0 +1,5 @@
+---
+githubHandle: amyrrich
+latitude: 42.360082
+longitude: -71.058880
+---

--- a/_pins/f-minzoni.json
+++ b/_pins/f-minzoni.json
@@ -1,0 +1,5 @@
+---
+githubHandle: f-minzoni
+latitude: 45.465422
+longitude: 9.185924
+---

--- a/_pins/itjarl1984.json
+++ b/_pins/itjarl1984.json
@@ -1,0 +1,5 @@
+---
+githubHandle: itjarl1984
+latitude: 36.114707
+longitude: -115.172850
+---

--- a/_pins/nilsabs.json
+++ b/_pins/nilsabs.json
@@ -1,0 +1,5 @@
+---
+githubHandle: nilsabs
+latitude: 59.913869
+longitude: 10.752245
+---

--- a/_pins/sophiehe.json
+++ b/_pins/sophiehe.json
@@ -1,0 +1,5 @@
+---
+githubHandle: sophiehe
+latitude: 34.0522
+longitude: -118.2437
+---

--- a/_pins/thierry-inno21-git.json
+++ b/_pins/thierry-inno21-git.json
@@ -1,0 +1,5 @@
+---
+githubHandle: thierry-inno21-git
+latitude: 48.8584
+longitude: 2.2945
+---


### PR DESCRIPTION
The old process used GitHub classroom to add students to this repository as collaborators. Unfortunately, this meant people could create adhoc teams which also created a new repository instead of allowing everyone to contribute to this repository. 

We have changed our process to use web hooks to add collaborators instead of classroom. This PR is the final step in cleaning up from the old process.

- [x] Deleted the teams and repositories created in error
- [x] Copy any completed json files from those repositories into this one

@githubschool/training-team will :ship: with one 👍 