### PR TITLE
Fixing file format and moving to _pins folder

### DIFF
--- a/Snack-Pack
+++ b/Snack-Pack
@@ -1,5 +1,0 @@
-githubHandle: Snack-Pack
-latitude: 28.510550
-longitude: -81.455871
-
-Add Username and coordinates

--- a/_pins/Snack-Pack.json
+++ b/_pins/Snack-Pack.json
@@ -1,5 +1,5 @@
+---
 githubHandle: Snack-Pack
 latitude: 28.510550
 longitude: -81.455871
-
-Add Username and coordinates
+---


### PR DESCRIPTION
@Snack-Pack I noticed that your file was not appearing on the map because it was not in the _pins directory and the formatting was a little off. I have fixed it in this Pull Request. Please feel free to merge this in after you have taken a look at the changes!

