### PR TITLE
Update file name and formatting of pin

### DIFF
--- a/_pins/MTaylr.json
+++ b/_pins/MTaylr.json
@@ -1,3 +1,5 @@
+---
 githubHandle: MTaylr
 latitude:  43.653226
 longitude: 79.383184
+---


### PR DESCRIPTION
Hey @MTaylr I noticed that you had created a folder named MTaylr and then placed a single file inside called `.json`. I fixed it so that your file is now named `MTaylr.json` and exists inside the `_pins` directory.

Also, the file format is very picky and needs to have a `---` at the beginning and end. I added it in this pull request. Please take a moment to look over the changes in this pull request and then click the big green merge button.