### PR TITLE
Add Potrero Hill SF to map

### DIFF
--- a/_pins/johndaley89.json
+++ b/_pins/johndaley89.json
@@ -1,0 +1,5 @@
+---
+githubHandle: johndaley89
+latitude: 37.7577366
+longitude: -122.40779,13.76
+---


### PR DESCRIPTION
I have added the neighbourhood of Potrero Hill in San Francisco to the map @githubteacher. Closes #1546 