### PR TITLE
Add PIN for Roanoke

### DIFF
--- a/_pins/bpary.json
+++ b/_pins/bpary.json
@@ -1,0 +1,5 @@
+---
+githubhandle: bpary
+latitude: 37.270970
+longitude: -79.941427
+---


### PR DESCRIPTION
Created a new PIN for Roanoke, VA based on instructions from @githubteacher.