### PR TITLE
Add syntax corrections for pin

### DIFF
--- a/_pins/BURQUIDI.json
+++ b/_pins/BURQUIDI.json
@@ -1,5 +1,5 @@
 ---
-githubHandle:burquidi
-latitude:41,9951
-longitude:1,5178
+githubHandle: burquidi
+latitude: 41.9951
+longitude: 1.5178
 ---

--- a/_pins/CrowOnslaught.json
+++ b/_pins/CrowOnslaught.json
@@ -1,5 +1,5 @@
 ---
-gitHubHandle:CrowOnslaught
-Latitude:41.439985
-Longitude:2.219762
+githubHandle: CrowOnslaught
+latitude: 41.439985
+longitude: 2.219762
 ---

--- a/_pins/FrancLl.json
+++ b/_pins/FrancLl.json
@@ -1,5 +1,5 @@
 ---
-githubHandle:FrancLl
-latitude:41.468470
-longitude:2.285048
+githubHandle: FrancLl
+latitude: 41.468470
+longitude: 2.285048
 ---

--- a/_pins/JRuiz7.json
+++ b/_pins/JRuiz7.json
@@ -1,5 +1,5 @@
 ---
-githubHandle:JRuiz7
-latitude:41.6167
-longitude:2.55
+githubHandle: JRuiz7
+latitude: 41.6167
+longitude: 2.55
 ---

--- a/_pins/SergioLindes.json
+++ b/_pins/SergioLindes.json
@@ -1,7 +1,5 @@
 ---
-
-githubHandle:SergioLindes
-latitude:41.5385827
-longitude:2.4418133
-
+githubHandle: SergioLindes
+latitude: 41.5385827
+longitude: 2.4418133
 ---

--- a/_pins/Somtha.json
+++ b/_pins/Somtha.json
@@ -1,5 +1,5 @@
 ---
 githubHandle: Somtha
-latidude: 72.8777° E
-longitude: 19.0760° N
+latidude: 72.8777
+longitude: 19.0760
 ---

--- a/_pins/abhi.json
+++ b/_pins/abhi.json
@@ -1,5 +1,5 @@
---
-githunhandle: abhi
+---
+githubHandle: abhi
 latitude: 20.593684
 longitude: 78.96288
---
+---

--- a/_pins/elissaunrau.json
+++ b/_pins/elissaunrau.json
@@ -3,4 +3,3 @@ githubHandle: elissaunrau
 latitude: 45.421530
 longitude: -75.697193
 ---
-

--- a/_pins/himyfairy.json
+++ b/_pins/himyfairy.json
@@ -1,5 +1,5 @@
 ---
-githubHandle:himyfairy
-latitude:33.619875
-longitude:119.017514
+githubHandle: himyfairy
+latitude: 33.619875
+longitude: 119.017514
 ---

--- a/_pins/kevinGarciaGimenez23.json
+++ b/_pins/kevinGarciaGimenez23.json
@@ -1,7 +1,5 @@
 ---
-
-githubHandle:kevinGarciaGimenez23
-latitude:41.5960394
-longitude:2.4065239
-
+githubHandle: kevinGarciaGimenez23
+latitude: 41.5960394
+longitude: 2.4065239
 ---

--- a/_pins/ljuhe.json
+++ b/_pins/ljuhe.json
@@ -1,5 +1,5 @@
 ---
-githubHandle:ljuhe
-latitude:41.850507
-longitude:3.129816
+githubHandle: ljuhe
+latitude: 41.850507
+longitude: 3.129816
 ---

--- a/_pins/slaytin.json
+++ b/_pins/slaytin.json
@@ -1,5 +1,5 @@
 ---
-githubHandle:slaytin
-latitude:41.866237
-longitude:-87.608859
+githubHandle: slaytin
+latitude: 41.866237
+longitude: -87.608859
 ---

--- a/_pins/xeviarte.json
+++ b/_pins/xeviarte.json
@@ -1,5 +1,5 @@
 ---
 githubHandle: xeviarte
-latitude:  42.166915
+latitude: 42.166915
 longitude: 0.894930
 ---


### PR DESCRIPTION
This PR corrects some pins that had invalid syntax when doing the Jekyll build locally. I can 🚢 with 1 approval.