### PR TITLE
create pin for user allyorbase at Tegucigalpa

### DIFF
--- a/_pins/allyorbase.json
+++ b/_pins/allyorbase.json
@@ -1,0 +1,5 @@
+---
+githubHandle: allyorbase
+latitude: 14.072275
+longitude: -87.192136
+---


### PR DESCRIPTION
Adds a pin for github user allyorbase in the city of Tegucigalpa, Honduras.
Based on directions from @githubteacher.
Closes #404.