### PR TITLE
Add Nørre Nissum to the map

### DIFF
--- a/_pins/lassemaidalpedersen.json
+++ b/_pins/lassemaidalpedersen.json
@@ -1,0 +1,5 @@
+---
+githubHandle: lassemaidalpedersen
+latitude: 56.555726
+longitude: 8.398823
+---


### PR DESCRIPTION
Added Nørre Nissum, Denmark to the map.
@githubteacher 
closes #2071 