### PR TITLE
Allow Travis CI to run all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ before_script:
   - pip install --user yamale
 script:
   - yamllint _pins/*
-  - ruby tests/test_filesRootDirectory.rb
-  - ruby tests/test_fileEndingsPins.rb
-  - ruby tests/test_coordinateValidation.rb
+  - ruby -Itest tests/all.rb
   - bundle exec jekyll build

--- a/tests/all.rb
+++ b/tests/all.rb
@@ -1,0 +1,1 @@
+Dir[File.dirname(File.absolute_path(__FILE__)) + '/**/test_*.rb'].each {|file| require file }


### PR DESCRIPTION
Simplifies running all tests under `tests/` via Travis CI.
