### PR TITLE
Adding DirkStagger's coordinates

### DIFF
--- a/_pins/DirkStagger.json
+++ b/_pins/DirkStagger.json
@@ -1,0 +1,5 @@
+---
+githubHandle: DirkStagger
+latitude: 44.897412
+longitude: -93.325523
+---


### PR DESCRIPTION
@githutteacher How did I do?

Adding DirkStagger-Edina pin to the map closes #927.