### PR TITLE
Adding zacheryjob pin to the map

### DIFF
--- a/_pins/zacheryjob.json
+++ b/_pins/zacheryjob.json
@@ -1,0 +1,5 @@
+---
+githubHandle: zacheryjob
+latitude: 43.850251
+longitude: -79.019938
+---


### PR DESCRIPTION
Adding zacheryjob pin to the map. This closes issue #4162 @githubteacher