### PR TITLE
Fix for issue on Beaverton Add

### DIFF
--- a/_pins/jarobey.json
+++ b/_pins/jarobey.json
@@ -1,0 +1,5 @@
+---
+githubHandle: jarobey
+latitude: 45.537502
+longitude: -122.844233
+---


### PR DESCRIPTION
Adding pin file to put Beaverton, OR on the map.

@githubteacher what do you think?

closes #5279 