### PR TITLE
Change ruby to http instead of https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "https://rubygems.org"
+source "http://rubygems.org"
 
 gem "jekyll"


### PR DESCRIPTION
Builds were failing, and it had to do with some fun SSL happenings in Ruby. This fix can be re-worked in the future when SSL things are fixed, but this will get the builds green here.
