### PR TITLE
Add llcawthorne-Columbia pin

### DIFF
--- a/_pins/llcawthorne.json
+++ b/_pins/llcawthorne.json
@@ -1,0 +1,5 @@
+---
+githubHandle: llcawthorne
+latitude: 33.990
+longitude: -81.035
+---


### PR DESCRIPTION
Adding pin for llcawthorne's home location of Columbia, SC under tutelage of @githubteacher.  closes #6263 