### PR TITLE
Add pin for user ericwk

### DIFF
--- a/_pins/ericwk.json
+++ b/_pins/ericwk.json
@@ -1,0 +1,5 @@
+---
+githubHandle: ericwk
+latitude: 41.4738
+longitude: -87.8377
+---


### PR DESCRIPTION
I propose to add a pin for user ericwk to the open-enrollment-classes-introduction-to-github map as guided by @githubteacher 