### PR TITLE
Update lat/long numbers in joshulus.json

### DIFF
--- a/_pins/joshulus.json
+++ b/_pins/joshulus.json
@@ -1,5 +1,5 @@
 ---
 githubHandle: Joshulus
-latitude: 40.457
-longitude: -79.916
+latitude: 40.457165
+longitude: -79.916834
 ---


### PR DESCRIPTION
Pin was not on the map, so the latitude longitude numbers were updated in an attempt to locate the pin.