### PR TITLE
Create vendarkII.json

### DIFF
--- a/_pins/vendarkII.json
+++ b/_pins/vendarkII.json
@@ -1,0 +1,5 @@
+---
+githubHandle: vendarkII
+latitude: 41.895
+longitude: -87.611
+---


### PR DESCRIPTION
Adding vendarkII's pin to map by making **vendarkII.json** and including the user, latitude, and longitude. @githubteacher 

closes #8688 