### PR TITLE
Add invitation link to teacherbot response

### DIFF
--- a/.github/teacherbot.yml
+++ b/.github/teacherbot.yml
@@ -1,5 +1,5 @@
 addCollaborators:
-  newCollaboratorMessage: "Hi! I\'m the friendly :robot: of this repo.\n\nWe\'re happy you\'re here :wave:. Everyone is welcome here, so I\'m making you a collaborator. This will give you access to commit on this repo."		   
+  newCollaboratorMessage: "Hi! I\'m the friendly :robot: of this repo.\n\nWe\'re happy you\'re here :wave:. Everyone is welcome here, so I\'m making you a collaborator. This will give you access to commit on this repo. Please [accept my invitation](https://github.com/githubschool/open-enrollment-classes-introduction-to-github/invitations) before moving on."		   
   existingCollaboratorMessage: "Hi! I\'m the friendly :robot: of this repo.\n\nI can see that you\'re already a collaborator. Any other issues are above my paygrade at the moment, so we\'ll have to wait for a pesky hu-man. Not to worry though, they\'ll drop by within 24 hours to answer your questions!"		   
 remindMerge:
   message: ":tada: Congratulations, you have finished this course. Please take a moment to tell us what you think in our [quick survey](http://www.surveygizmo.com/s3/3288550/intro-to-github).\n\nAlso, please remember to delete your branch if you haven\'t done so already."


### PR DESCRIPTION
Now that repository invitation requirements are live, this PR just adjusts the response from Teacherbot. 