### PR TITLE
add West Long Branch, NJ to map

### DIFF
--- a/_pins/jtrohn.json
+++ b/_pins/jtrohn.json
@@ -1,0 +1,5 @@
+---
+githubHandle: jtrohn
+latitude: 40.280442
+longitude: -74.005795
+---


### PR DESCRIPTION
This is the location of Monmouth University in West Long Branch, NJ.
Fixes #11116 
@githubteacher 