### PR TITLE
Add coordinates for Kanpur, UP, India

### DIFF
--- a/_pins/lbandlish.json
+++ b/_pins/lbandlish.json
@@ -1,0 +1,5 @@
+---
+githubHandle: lbandlish
+latitude: 26.4667
+longitude: 80.35
+---


### PR DESCRIPTION
Merge the *json* file containing the coordinates for IIT Kanpur, Kanpur. @githubteacher 
closes #12315 