### PR TITLE
Add WNYmathGuy's pin to the map, please.

### DIFF
--- a/_pins/WNYmathGuy.json
+++ b/_pins/WNYmathGuy.json
@@ -1,0 +1,5 @@
+---
+githubHandle: WNYmathGuy
+latitude: 43.006946
+longitude: -78.752489
+---


### PR DESCRIPTION
I like NASA too, but alternatively a right-click on Google Maps then select "What's here?" will also get the Lat & Long cords as a clickable link at the bottom of the page, and clicking that link produces the degree, minute, second, NSEW conversion too.

What the fuck is "closes #940"?