### PR TITLE
Add don-montgomery's coordinates to map

### DIFF
--- a/_pins/don-montgomery.json
+++ b/_pins/don-montgomery.json
@@ -1,0 +1,6 @@
+---
+githubHandle: don-montgomery
+latitude: -95.184663
+longitude: 32.973734
+---
+


### PR DESCRIPTION
May involve a change from less precise coordinates added earlier via different interface (different interface was a non-code webpage form).

Pull request is made to training team via @githubteacher .

Cannot find an issue number associated with this task.