### PR TITLE
Adding adoling's coordinates

### DIFF
--- a/_pins/adoling.json
+++ b/_pins/adoling.json
@@ -1,0 +1,5 @@
+---
+githubHandle: adoling
+latitude: 38.889931
+longitude: -77.009003
+---


### PR DESCRIPTION
Adds latitude and longitude for Washington, DC, @githubteacher

closes #20874

